### PR TITLE
Switch to LMDB backend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,9 @@
 # modules for authentication, and OpenSSL for certificate generation.
 FROM alpine:3.20
 
-# ─── Edge-Repos für fix für gdbm_errno=3 (Cyrus-SASL ≥2.1.27-r12) ───
-RUN echo "https://dl-cdn.alpinelinux.org/alpine/edge/main"      >> /etc/apk/repositories && \
-    echo "https://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
-    apk update
+
+# Use the standard repositories; SASL stores credentials in an LMDB database
+# to avoid gdbm-related issues on Alpine.
 
 # Metadata
 LABEL maintainer="Postfix Relay Maintainer <maintainer@example.com>"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ downstream receivers that distrust dynamic address space.
 ## Features
 
 * **Lightweight:** built on Alpine Linux with only Postfix, Cyrus
-  SASL and OpenSSL installed.  The resulting image is under 100 MB.
+  SASL (using an LMDB backend) and OpenSSL installed.  The resulting image is under 100 MB.
 * **Runtime configuration:** environment variables control all
   essential parameters.  You never edit `main.cf` or `master.cf`
   directly; the entrypoint script rewrites settings using
@@ -84,12 +84,12 @@ Upon start the container runs `entrypoint.sh`.  This script:
    `/dev/stdout`, so that Postfix logs to standard output【819524448154663†L49-L64】.
 4. Creates a Cyrus SASL database when `ENABLE_SASL=true` and the
    user and password are provided.  The credentials are stored in
-   `/etc/sasldb2` and persist across restarts thanks to the
-   `sasl-db` volume.
-5. Optionally creates a `sasl_passwd.db` map for authenticating to
-   an upstream smarthost if `RELAYHOST`, `RELAYHOST_USERNAME` and
-   `RELAYHOST_PASSWORD` are set.  Postfix uses this map via
-   `smtp_sasl_password_maps`.
+   `/etc/sasldb2` using the LMDB format and persist across restarts
+   thanks to the `sasl-db` volume.
+5. Optionally creates a `sasl_passwd.db` map (stored as LMDB) for
+   authenticating to an upstream smarthost if `RELAYHOST`,
+   `RELAYHOST_USERNAME` and `RELAYHOST_PASSWORD` are set.  Postfix
+   uses this map via `smtp_sasl_password_maps`.
 6. Finally executes `postfix start-fg`, which keeps Postfix in the
    foreground as PID 1.  Support for foreground operation was
    introduced in Postfix 3.3【219023648407850†L19-L25】.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -84,7 +84,7 @@ maybe_setup_sasl() {
 pwcheck_method: auxprop
 auxprop_plugin: sasldb
 mech_list: PLAIN LOGIN CRAM-MD5 DIGEST-MD5
-sasldb_path: /etc/sasl2/sasldb2.mdb #/etc/sasl2/sasldb2
+sasldb_path: /etc/sasl2/sasldb2.mdb # LMDB database
 EOF
 }
 
@@ -97,10 +97,11 @@ maybe_setup_relayhost_auth() {
   update_postconf relayhost "$RELAYHOST"
   if [[ -n "$RELAYHOST_USERNAME" && -n "$RELAYHOST_PASSWORD" ]]; then
     echo "$RELAYHOST $RELAYHOST_USERNAME:$RELAYHOST_PASSWORD" > /etc/postfix/sasl_passwd
-    postmap hash:/etc/postfix/sasl_passwd
+    # Explicitly build the map using LMDB to avoid the gdbm backend
+    postmap lmdb:/etc/postfix/sasl_passwd
     rm -f /etc/postfix/sasl_passwd
     update_postconf smtp_sasl_auth_enable yes
-    update_postconf smtp_sasl_password_maps hash:/etc/postfix/sasl_passwd.db
+    update_postconf smtp_sasl_password_maps lmdb:/etc/postfix/sasl_passwd.db
     update_postconf smtp_sasl_security_options noanonymous
     update_postconf smtp_sasl_tls_security_options noanonymous
   fi


### PR DESCRIPTION
## Summary
- update Dockerfile to use LMDB based SASL storage
- mention LMDB usage in documentation
- explicitly create Postfix maps with LMDB

## Testing
- `bash -n entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_e_6888ea01fe888321ae80c0ceb623c837