### PR TITLE
Switch to Dovecot SASL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ downstream receivers that distrust dynamic address space.
 
 ## Features
 
-* **Lightweight:** built on Alpine Linux with only Postfix, Cyrus
-  SASL and OpenSSL installed.  The resulting image is under 100 MB.
+* **Lightweight:** built on Alpine Linux with Postfix and Dovecot for
+  SASL authentication. The resulting image is under 100 MB.
 * **Runtime configuration:** environment variables control all
   essential parameters.  You never edit `main.cf` or `master.cf`
   directly; the entrypoint script rewrites settings using
@@ -22,7 +22,8 @@ downstream receivers that distrust dynamic address space.
   via a volume.
 * **Optional client authentication:** enable SASL by toggling
   `ENABLE_SASL=true` and specifying a client `SMTP_USERNAME` and
-  `SMTP_PASSWORD`.  Only authenticated users and hosts listed in
+  `SMTP_PASSWORD`. Authentication is provided by the Dovecot
+  SASL service. Only authenticated users and hosts listed in
   `ALLOWED_NETWORKS` may relay mail.
 * **Smarthost support:** optionally forward all outbound mail to an
   upstream SMTP server (e.g. your ISP) with support for SMTP AUTH.
@@ -82,16 +83,19 @@ Upon start the container runs `entrypoint.sh`.  This script:
    `myhostname`, `mydomain`, `mynetworks` and other relay
    essentials.  It also configures `maillog_file` to
    `/dev/stdout`, so that Postfix logs to standard output【819524448154663†L49-L64】.
-4. Creates a Cyrus SASL database when `ENABLE_SASL=true` and the
+4. Creates a Dovecot password file when `ENABLE_SASL=true` and the
    user and password are provided.  The credentials are stored in
-   `/etc/sasldb2` and persist across restarts thanks to the
+   `/etc/dovecot/users` and persist across restarts thanks to the
    `sasl-db` volume.
-5. Optionally creates a `sasl_passwd.db` map for authenticating to
-   an upstream smarthost if `RELAYHOST`, `RELAYHOST_USERNAME` and
-   `RELAYHOST_PASSWORD` are set.  Postfix uses this map via
-   `smtp_sasl_password_maps`.
-6. Finally executes `postfix start-fg`, which keeps Postfix in the
+5. Optionally creates a `sasl_passwd.db` map (stored as LMDB) for
+   authenticating to an upstream smarthost if `RELAYHOST`,
+   `RELAYHOST_USERNAME` and `RELAYHOST_PASSWORD` are set.  Postfix
+   uses this map via `smtp_sasl_password_maps`.
+6. When SASL is enabled the entrypoint launches the Dovecot daemon
+   so Postfix can verify credentials.
+7. Finally executes `postfix start-fg`, which keeps Postfix in the
    foreground as PID 1.  Support for foreground operation was
    introduced in Postfix 3.3【219023648407850†L19-L25】.
 
 For further tuning consult the [Postfix documentation](https://www.postfix.org/documentation.html).
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,18 +19,18 @@ services:
     # automatically read the .env file in the same directory.
     env_file:
       - .env
-    # Persist certificates and SASL databases across container
+    # Persist certificates and Dovecot state across container
     # restarts.  Without these volumes the container will generate
     # a new self‑signed certificate and credentials each time it
-    # starts.  The `sasl-db` volume stores /etc/sasldb2, while
+    # starts.  The `sasl-db` volume stores /etc/dovecot, while
     # `certs` stores generated TLS materials.
     volumes:
       - certs:/etc/postfix/certs
-      # Persist SASL database on the host.  This file stores the
+      # Persist Dovecot user database on the host.  This file stores the
       # credentials created when SASL is enabled.  Mount it as a
       # single file so that it survives container recreation without
       # overwriting the rest of /etc.
-      - sasl-db:/etc/sasl2
+      - sasl-db:/etc/dovecot
     # To log via syslog on the host you may mount /dev/log:
     # - "/dev/log:/dev/log"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,21 +31,6 @@ sed -ri '
 touch /etc/postfix/aliases
 newaliases
 
-# ─── Recreate SASL DB if needed ───
-if [[ "${ENABLE_SASL,,}" == "true" && -n "$SMTP_USERNAME" && -n "$SMTP_PASSWORD" ]]; then
-  rm -f /etc/sasl2/sasldb2.mdb
-  echo "[INFO] Re-creating SASL user database at /etc/sasl2/sasldb2.mdb"
-  echo "$SMTP_PASSWORD" \
-  | saslpasswd2 -c -p -f /etc/sasl2/sasldb2.mdb -u "$RELAY_DOMAIN" "$SMTP_USERNAME"
-  #echo "$SMTP_PASSWORD" \
-  #  | saslpasswd2 -c -p -f /etc/sasl2/sasldb2.mdb -u "$RELAY_DOMAIN" "$SMTP_USERNAME"
-  chown postfix:postfix /etc/sasl2/sasldb2.mdb
-  chmod 600 /etc/sasl2/sasldb2.mdb
-
-  echo "[DEBUG] SASL DB file details: $(ls -lh /etc/sasl2/sasldb2.mdb)"
-  echo "[DEBUG] SASL users:"
-  sasldblistusers2 -f /etc/sasl2/sasldb2.mdb || echo "[DEBUG] Failed to list users"
-fi
 
 # ─── Helper: update postconf only if changed ───
 update_postconf() {
@@ -75,17 +60,38 @@ maybe_setup_sasl() {
     return
   fi
   update_postconf smtpd_sasl_auth_enable yes
-  update_postconf smtpd_sasl_type cyrus
-  update_postconf smtpd_sasl_path smtpd
+  update_postconf smtpd_sasl_type dovecot
+  update_postconf smtpd_sasl_path private/auth
   update_postconf smtpd_sasl_local_domain "$RELAY_DOMAIN"
   update_postconf smtpd_sasl_security_options noanonymous
   update_postconf smtpd_tls_auth_only no
-  cat > /etc/sasl2/smtpd.conf <<EOF
-pwcheck_method: auxprop
-auxprop_plugin: sasldb
-mech_list: PLAIN LOGIN CRAM-MD5 DIGEST-MD5
-sasldb_path: /etc/sasl2/sasldb2.mdb #/etc/sasl2/sasldb2
+  mkdir -p /etc/dovecot
+  cat > /etc/dovecot/dovecot.conf <<'EOF'
+disable_plaintext_auth = no
+auth_mechanisms = plain login cram-md5 digest-md5
+passdb {
+  driver = passwd-file
+  args = /etc/dovecot/users
+}
+userdb {
+  driver = static
+  args = uid=postfix gid=postfix home=/var/empty
+}
+service auth {
+  unix_listener /var/spool/postfix/private/auth {
+    mode = 0660
+    user = postfix
+    group = postfix
+  }
+}
 EOF
+  if [[ -n "$SMTP_USERNAME" && -n "$SMTP_PASSWORD" ]]; then
+    echo "$SMTP_USERNAME:{PLAIN}$SMTP_PASSWORD" > /etc/dovecot/users
+    chown root:root /etc/dovecot/users
+    chmod 600 /etc/dovecot/users
+  else
+    echo "[WARN] SASL enabled but SMTP_USERNAME/SMTP_PASSWORD not provided; clients will be unable to authenticate"
+  fi
 }
 
 # ─── Configure relayhost auth if provided ───
@@ -97,13 +103,21 @@ maybe_setup_relayhost_auth() {
   update_postconf relayhost "$RELAYHOST"
   if [[ -n "$RELAYHOST_USERNAME" && -n "$RELAYHOST_PASSWORD" ]]; then
     echo "$RELAYHOST $RELAYHOST_USERNAME:$RELAYHOST_PASSWORD" > /etc/postfix/sasl_passwd
-    postmap hash:/etc/postfix/sasl_passwd
+    # Explicitly build the map using LMDB to avoid the gdbm backend
+    postmap lmdb:/etc/postfix/sasl_passwd
     rm -f /etc/postfix/sasl_passwd
     update_postconf smtp_sasl_auth_enable yes
-    update_postconf smtp_sasl_password_maps hash:/etc/postfix/sasl_passwd.db
+    update_postconf smtp_sasl_password_maps lmdb:/etc/postfix/sasl_passwd.db
     update_postconf smtp_sasl_security_options noanonymous
     update_postconf smtp_sasl_tls_security_options noanonymous
   fi
+}
+
+# ─── Start Dovecot if SASL enabled ───
+start_dovecot() {
+  if [[ "${ENABLE_SASL,,}" != "true" ]]; then return; fi
+  echo "[INFO] Starting Dovecot for SASL authentication"
+  dovecot
 }
 
 # ─── Apply base Postfix configuration ───
@@ -139,6 +153,7 @@ main() {
   apply_base_configuration
   maybe_setup_sasl
   maybe_setup_relayhost_auth
+  start_dovecot
   postfix check
   echo "[INFO] Starting Postfix in foreground…"
   exec postfix start-fg


### PR DESCRIPTION
## Summary
- replace cyrus-sasl with dovecot for SASL authentication
- update entrypoint to configure and start dovecot
- persist dovecot users via docker-compose volume
- document dovecot usage and adjust feature list

## Testing
- `bash -n entrypoint.sh`


------
https://chatgpt.com/codex/tasks/task_e_6888ea01fe888321ae80c0ceb623c837